### PR TITLE
Refactor utilities and deduplicate functions

### DIFF
--- a/code/distillation/data_manager.py
+++ b/code/distillation/data_manager.py
@@ -1,23 +1,8 @@
 from transformers import AutoTokenizer
 from datasets import DatasetDict
-
-def tokenize_data(example, tokenizer):
-    """Tokenizes a single data example."""
-    return tokenizer(example['sentence'], padding='max_length', truncation=True)
+from toolbox.utils import tokenize_data
 
 def get_tokenized_lang_dataset(tokenizer: AutoTokenizer, dataset: DatasetDict, lang: str) -> DatasetDict:
     """Filters a dataset by language and tokenizes it."""
     raw_dataset = dataset.filter(lambda example: example['lang'] == lang)
-    return raw_dataset.map(lambda example: tokenize_data(example, tokenizer), batched=True)
-
-def transform_labels(examples):
-    """Transforms sentiment labels from strings to integers."""
-    label_map = {"negative": 0, "neutral": 1, "positive": 2}
-    # Handle both single examples and batches
-    if isinstance(examples['sentiment'], list):
-        examples['labels'] = [label_map[s.lower()] for s in examples['sentiment']]
-    else:
-        # Handle potential non-string or unexpected format gracefully
-        sentiment_str = str(examples.get('sentiment', '')).lower()
-        examples['labels'] = label_map.get(sentiment_str, -1) # Use -1 or some indicator for unknown labels
-    return examples 
+    return raw_dataset.map(lambda example: tokenize_data(tokenizer, example), batched=True)

--- a/code/distillation/evaluation.py
+++ b/code/distillation/evaluation.py
@@ -1,14 +1,5 @@
 import torch
-import evaluate
 from sklearn.metrics import accuracy_score, precision_recall_fscore_support
-
-metric = evaluate.load("accuracy")
-
-def compute_metrics(eval_pred):
-    """Computes accuracy metric for trainer evaluation."""
-    logits, labels = eval_pred
-    predictions = torch.argmax(torch.tensor(logits), dim=1).numpy()
-    return metric.compute(predictions=predictions, references=labels)
 
 def evaluate(model, dataloader, device):
     """Evaluates a model on a given dataloader.

--- a/code/distillation/main.py
+++ b/code/distillation/main.py
@@ -10,7 +10,7 @@ from torch.optim import Adam
 from torch.cuda.amp import GradScaler
 
 # Local imports from the refactored modules
-from data_manager import transform_labels, tokenize_data
+from toolbox.utils import transform_labels, tokenize_data
 from evaluation import evaluate
 from model_trainer import fine_tune_language
 from distillation import DistillationTrainer
@@ -144,7 +144,7 @@ logger.log("Preparing data for distillation...", type="INFO")
 tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL_NAME) # Use base tokenizer for student
 
 # Tokenize the entire dataset once
-tokenized_dataset = complete_dataset.map(lambda ex: tokenize_data(ex, tokenizer), batched=True,
+tokenized_dataset = complete_dataset.map(lambda ex: tokenize_data(tokenizer, ex), batched=True,
                                          remove_columns=['sentence', 'lang']) # Remove unused columns
 
 # Ensure 'labels' column exists after transformations
@@ -233,7 +233,7 @@ logger.log("Loading synthetic dataset...", type="INFO")
 synthetic_ds = load_dataset("nojedag/synthetic_financial_sentiment")
 synthetic_dataset = synthetic_ds.map(transform_labels, batched=True, remove_columns=['sentiment'])
 logger.log("Tokenizing synthetic data...", type="INFO")
-tokenized_synthetic = synthetic_dataset.map(lambda ex: tokenize_data(ex, tokenizer), batched=True, remove_columns=['sentence', 'lang'])
+tokenized_synthetic = synthetic_dataset.map(lambda ex: tokenize_data(tokenizer, ex), batched=True, remove_columns=['sentence', 'lang'])
 tokenized_synthetic.set_format(type="torch", columns=["input_ids", "attention_mask", "labels"])
 synthetic_loader = DataLoader(tokenized_synthetic['train'], batch_size=BATCH_SIZE) # Assuming 'train' split
 logger.log("Evaluating student model on synthetic data...", type="INFO")

--- a/code/distillation/model_trainer.py
+++ b/code/distillation/model_trainer.py
@@ -10,7 +10,7 @@ from transformers import (
 )
 from datasets import DatasetDict
 from data_manager import get_tokenized_lang_dataset # Import from the new module
-from evaluation import compute_metrics # Import from the new module
+from toolbox.utils import compute_metrics
 from transformers import EarlyStoppingCallback
 from collections import Counter
 

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -25,6 +25,10 @@ def compute_metrics(eval_pred):
     f1 = load_f1.compute(predictions=predictions, references=labels, average="weighted")
     return {"accuracy": accuracy, "f1score": f1}
 
+def tokenize_data(tokenizer, example):
+    """Tokenize a data example using the provided tokenizer."""
+    return tokenizer(example['sentence'], padding='max_length', truncation=True)
+
 def get_output_dir(model_name):
     return f'.././models/{model_name}'
 


### PR DESCRIPTION
## Summary
- centralize tokenization, label mapping and metrics in `toolbox.utils`
- remove repeated functions from finetuning and distillation modules
- import common helpers from `toolbox.utils`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407f3489948321aa36b5fe3ded1211